### PR TITLE
Kamon tracing

### DIFF
--- a/diag/src/main/resources/reference.conf
+++ b/diag/src/main/resources/reference.conf
@@ -1,0 +1,42 @@
+##
+## To see default values and all possible configurations, look into reference.conf file shipped with Kamon library.
+##
+kamon.influxdb {
+
+  # Hostname and port in which your InfluxDB is running
+  hostname = "127.0.0.1"
+  port = 8086
+
+  # The database where to write in InfluxDB.
+  database = "testDB"
+}
+
+kamon {
+  jaeger {
+
+    # Define the host/port where the Jaeger Collector/Agent is listening.
+    host = "localhost"
+    port = 14268
+
+    # Protocol used to send data to Jaeger. The available options are:
+    #   - http: Sends spans using jaeger.thrift over HTTP. Aimed to used with a Jaeger Collector.
+    #   - https: Sends spans using jaeger.thrift over HTTPS. Aimed to used with a Jaeger Collector.
+    #   - udp: Sends spans using jaeger.thrift compact over UDP. Aimed to used with a Jaeger Agent.
+    protocol = http
+
+    # for http and https, this is the full url to be used
+    http-url = ${kamon.jaeger.protocol}"://"${kamon.jaeger.host}":"${kamon.jaeger.port}"/api/traces"
+
+    # Enable or disable including tags from kamon.environment as labels
+    include-environment-tags = no
+  }
+
+  modules {
+    jaeger {
+      enabled = true
+      name = "Jaeger Reporter"
+      description = "Sends Spans to Jaeger over HTTP"
+      factory = "kamon.jaeger.JaegerReporterFactory"
+    }
+  }
+}

--- a/diag/src/main/scala/rhonix/diagnostics/KamonDiagnostics.scala
+++ b/diag/src/main/scala/rhonix/diagnostics/KamonDiagnostics.scala
@@ -1,10 +1,12 @@
 package rhonix.diagnostics
 
+import cats.effect.kernel.Outcome
 import cats.effect.{Resource, Sync}
 import com.typesafe.config.Config
 import kamon.Kamon
 import kamon.metric.Timer
 import kamon.tag.TagSet
+import kamon.trace.Span
 
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
@@ -27,13 +29,33 @@ object KamonDiagnostics {
    * @tparam F
    * @return
    */
-  private def timer[F[_]: Sync](name: String, tags: Map[String, Any]): Resource[F, Unit] = {
+  private def timer[F[_]: Sync](name: String, tags: Map[String, Any]): Resource[F, Timer.Started] = {
     val start                  = Sync[F].delay(Kamon.timer(name).withTags(TagSet.from(tags)).start())
     def stop(t: Timer.Started) = Sync[F].delay(t.stop())
-    Resource.make(start)(stop).map(_ => ())
+    Resource.make(start)(stop)
+  }
+
+  // Adaptation of Kamon's function span(operationName: String, component: String)(f: => A): A to cats-effect
+  private def span[F[_]: Sync, A](opName: String, component: String)(f: F[A]) = Sync[F].defer {
+    val span  = Kamon
+      .spanBuilder(opName)
+      .kind(Span.Kind.Internal)
+      .tagMetrics(Span.TagKeys.Component, component)
+      .start()
+    val ctx   = Kamon.currentContext().withEntry(Span.Key, span)
+    val scope = Kamon.storeContext(ctx)
+
+    Sync[F].guaranteeCase(f) {
+      case Outcome.Errored(err) => Sync[F].delay(span.fail(err.getMessage, err).finish())
+      case _                    => Sync[F].delay { span.finish(); scope.close() }
+    }
   }
 
   def logTime[F[_]: Sync, T](f: => F[T])(name: String, tags: Map[String, Any] = Map()): F[T] = Sync[F].defer {
     if (Kamon.enabled()) timer(name, tags).surround(f) else f
+  }
+
+  def span[F[_]: Sync, T](f: => F[T])(opName: String, component: String): F[T] = Sync[F].defer {
+    if (Kamon.enabled()) span(opName, component)(f) else f
   }
 }

--- a/diag/src/main/scala/rhonix/diagnostics/syntax/KamonSyntax.scala
+++ b/diag/src/main/scala/rhonix/diagnostics/syntax/KamonSyntax.scala
@@ -6,6 +6,10 @@ import rhonix.diagnostics.KamonDiagnostics
 final class KamonSyntax[F[_], T](private val f: F[T]) extends AnyVal {
   def kamonTimer(name: String, tags: Map[String, Any] = Map())(implicit syncF: Sync[F]): F[T] =
     KamonDiagnostics.logTime(f)(name, tags)
+
+  def kamonTrace(opName: String, component: String)(implicit syncF: Sync[F]): F[T] =
+    KamonDiagnostics.span(f)(opName, component)
+
 }
 
 object KamonSyntax {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,10 +24,9 @@ object Dependencies {
   val scalatestScalacheck  = "org.scalatestplus" %% "scalacheck-1-17" % "3.2.16.0" % Test
 
   // Diagnostics
-  val kamon                 = "io.kamon" %% "kamon-core"        % "2.6.3"
-  val kamonStatus           = "io.kamon" %% "kamon-status-page" % "2.6.3"
-  val kamonInfluxDbReporter = "io.kamon" %% "kamon-influxdb"    % "2.6.0"
-  val kamonZipkinReporter   = "io.kamon" %% "kamon-jaeger"      % "2.6.0"
+  val kamonBundle           = "io.kamon" %% "kamon-bundle"   % "2.6.1"
+  val kamonInfluxDbReporter = "io.kamon" %% "kamon-influxdb" % "2.6.0"
+  val kamonJaegerReporter   = "io.kamon" %% "kamon-jaeger"   % "2.6.0"
 
   val http4sNetty = "org.http4s" %% "http4s-netty-server" % "0.5.9"
   val http4sBlaze = "org.http4s" %% "http4s-blaze-server" % "0.23.14"
@@ -46,7 +45,7 @@ object Dependencies {
 
   val common = Seq(catsCore, catsEffect, fs2Core)
 
-  val diagnostics = Seq(kamon, kamonStatus, kamonInfluxDbReporter, kamonZipkinReporter)
+  val diagnostics = Seq(kamonBundle, kamonInfluxDbReporter, kamonJaegerReporter)
 
   val http4s = Seq(http4sNetty, http4sDSL, circeCodec, http4sBlaze)
 


### PR DESCRIPTION
This PR adds `span` method to be able to record spans and observe execution traces. 
Please look at the test to see the usage.
This is the picture of a trace you should observe when running test with Jaeger started.
<img width="1593" alt="Screenshot 2023-08-26 at 09 05 40" src="https://github.com/Rhonix-Network/RhonixNode/assets/1746367/4042eb4e-1a76-43cf-8eec-4d6c2e25409b">
